### PR TITLE
API cleanup and internal refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" ST
     add_compile_options(-Werror)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
     add_compile_options(-Wall -Wextra -Wmissing-declarations -Wformat=2 -Wcast-qual -Wundef
-        -fdiagnostics-color=always -Wwrite-strings -Wimplicit-fallthrough)
+        -fdiagnostics-color=always -Wwrite-strings -Wimplicit-fallthrough -Wno-invalid-offsetof)
     add_compile_options(-Werror)
 elseif ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     # default warnings, treat warnings as errors

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ include(TargetArch)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang")
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
     add_compile_options(-Wall -Wextra -Wmissing-declarations -Wformat=2 -Wcast-qual -Wundef
         -fdiagnostics-color=always -Wwrite-strings -Wimplicit-fallthrough
         -Wno-unused-private-field)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ message(STATUS "Target architecture: ${TARGET_ARCH}")
 ### Use the manually specified arch code override, or autodetect it
 set(PLATFORM_LIBCOMMUNISM "Auto" CACHE STRING "Architecture specific code to be built")
 set_property(CACHE PLATFORM_LIBCOMMUNISM PROPERTY STRINGS Auto amd64-sysv amd64-win aarch64-aapcs
-    setjmp ucontext)
+    setjmp ucontext x86-fastcall)
 
 if("Auto" STREQUAL ${PLATFORM_LIBCOMMUNISM})
     if("x86_64" STREQUAL ${TARGET_ARCH})

--- a/src/AllocImpl.h
+++ b/src/AllocImpl.h
@@ -1,0 +1,48 @@
+#ifndef ALLOCIMPL_H
+#define ALLOCIMPL_H
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+#if defined(PLATFORM_AMD64_SYSV) || defined(PLATFORM_AMD64_WINDOWS)
+#include "arch/amd64/Common.h"
+#elif defined(PLATFORM_SETJMP)
+#include "arch/setjmp/SetJmp.h"
+#elif defined(PLATFORM_UCONTEXT)
+#include "arch/ucontext/UContext.h"
+#endif
+
+template <class ImplClass, typename ...Args>
+static constexpr auto AllocImplHelper(std::span<uintptr_t> buffer, bool &bufferUsed, Args && ...args) {
+    const auto bytes{buffer.size() * sizeof(uintptr_t)};
+
+    if(sizeof(ImplClass) <= bytes && alignof(ImplClass) <= sizeof(uintptr_t)) {
+        bufferUsed = true;
+        auto mem = reinterpret_cast<ImplClass *>(buffer.data());
+        return new(mem) ImplClass(std::forward<Args>(args)...);
+    } else {
+        bufferUsed = false;
+        return new ImplClass(std::forward<Args>(args)...);
+    }
+}
+
+/**
+ * Helper method to construct a new implementation.
+ */
+template <typename ...Args>
+static constexpr auto AllocImpl(std::span<uintptr_t> buffer, bool &bufferUsed, Args && ...args) {
+    using namespace libcommunism::internal;
+
+#if defined(PLATFORM_AMD64_SYSV) || defined(PLATFORM_AMD64_WINDOWS)
+    return AllocImplHelper<Amd64>(buffer, bufferUsed, std::forward<Args>(args)...);
+#elif defined(PLATFORM_SETJMP)
+    return AllocImplHelper<SetJmp>(buffer, bufferUsed, std::forward<Args>(args)...);
+#elif defined(PLATFORM_UCONTEXT)
+    return AllocImplHelper<UContext>(buffer, bufferUsed, std::forward<Args>(args)...);
+#else
+#error Don't know how to allocate implementation for current platform!
+#endif
+}
+
+#endif

--- a/src/AllocImpl.h
+++ b/src/AllocImpl.h
@@ -9,6 +9,8 @@
 #include "arch/amd64/Common.h"
 #elif defined(PLATFORM_X86_FASTCALL)
 #include "arch/x86/Common.h"
+#elif defined(PLATFORM_AARCH64_AAPCS)
+#include "arch/aarch64/Common.h"
 #elif defined(PLATFORM_SETJMP)
 #include "arch/setjmp/SetJmp.h"
 #elif defined(PLATFORM_UCONTEXT)
@@ -40,6 +42,8 @@ static constexpr auto AllocImpl(std::span<uintptr_t> buffer, bool &bufferUsed, A
     return AllocImplHelper<Amd64>(buffer, bufferUsed, std::forward<Args>(args)...);
 #elif defined(PLATFORM_X86_FASTCALL)
     return AllocImplHelper<x86>(buffer, bufferUsed, std::forward<Args>(args)...);
+#elif defined(PLATFORM_AARCH64_AAPCS)
+    return AllocImplHelper<Aarch64>(buffer, bufferUsed, std::forward<Args>(args)...);
 #elif defined(PLATFORM_SETJMP)
     return AllocImplHelper<SetJmp>(buffer, bufferUsed, std::forward<Args>(args)...);
 #elif defined(PLATFORM_UCONTEXT)

--- a/src/AllocImpl.h
+++ b/src/AllocImpl.h
@@ -7,6 +7,8 @@
 
 #if defined(PLATFORM_AMD64_SYSV) || defined(PLATFORM_AMD64_WINDOWS)
 #include "arch/amd64/Common.h"
+#elif defined(PLATFORM_X86_FASTCALL)
+#include "arch/x86/Common.h"
 #elif defined(PLATFORM_SETJMP)
 #include "arch/setjmp/SetJmp.h"
 #elif defined(PLATFORM_UCONTEXT)
@@ -36,6 +38,8 @@ static constexpr auto AllocImpl(std::span<uintptr_t> buffer, bool &bufferUsed, A
 
 #if defined(PLATFORM_AMD64_SYSV) || defined(PLATFORM_AMD64_WINDOWS)
     return AllocImplHelper<Amd64>(buffer, bufferUsed, std::forward<Args>(args)...);
+#elif defined(PLATFORM_X86_FASTCALL)
+    return AllocImplHelper<x86>(buffer, bufferUsed, std::forward<Args>(args)...);
 #elif defined(PLATFORM_SETJMP)
     return AllocImplHelper<SetJmp>(buffer, bufferUsed, std::forward<Args>(args)...);
 #elif defined(PLATFORM_UCONTEXT)

--- a/src/AllocImpl.h
+++ b/src/AllocImpl.h
@@ -41,7 +41,7 @@ static constexpr auto AllocImpl(std::span<uintptr_t> buffer, bool &bufferUsed, A
 #elif defined(PLATFORM_UCONTEXT)
     return AllocImplHelper<UContext>(buffer, bufferUsed, std::forward<Args>(args)...);
 #else
-#error Don't know how to allocate implementation for current platform!
+#error Do not know how to allocate implementation for current platform!
 #endif
 }
 

--- a/src/CothreadImpl.h
+++ b/src/CothreadImpl.h
@@ -1,0 +1,103 @@
+#ifndef LIBCOMMUNISM_COTHREADIMPL_H
+#define LIBCOMMUNISM_COTHREADIMPL_H
+
+#include <libcommunism/Cothread.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+
+namespace libcommunism {
+/**
+ * @brief Abstract interface for a platform implementation of cothreads
+ *
+ * Each platform implementation derives from this base class, meaning that the cothread API that we
+ * expose to callers is just a thin shim over an instance of this class. The concrete instances of
+ * this class will end up holding the actual state of the cothread.
+ */
+struct CothreadImpl {
+    using Entry = Cothread::Entry;
+
+    /**
+     * Initialize a cothread that begins execution at the given entry point, allocating a stack
+     * for it.
+     *
+     * @param entry Method to execute on entry to this cothread
+     * @param stackSize Size of the stack to be allocated, in bytes. it should be a multiple of
+     *        the machine word size, or specify zero to use the platform default.
+     */
+    CothreadImpl(const Cothread::Entry &entry, const size_t stackSize = 0) {
+        (void) entry, (void) stackSize;
+    }
+
+    /**
+     * Initialize the implementation to start execution at the given point with an already
+     * allocated stack.
+     *
+     * @remark This method should not take ownership of the stack buffer; it's expected that the
+     *         caller handles this, and ensures it's valid until the cothread is deallocated.
+     *
+     * @param entry Method to execute on entry to this cothread
+     * @param stack Buffer to use as the stack of the cothread
+     */
+    CothreadImpl(const Cothread::Entry &entry, std::span<uintptr_t> stack) : stack(stack) {
+        (void) entry;
+    }
+
+    /**
+     * Create a "skeleton" cothread that has only an associated stack.
+     *
+     * @param stack Buffer to use as the stack of the cothread
+     */
+    CothreadImpl(std::span<uintptr_t> stack) : stack(stack) {}
+
+    /**
+     * Clean up all resources associated with the cothread, such as its stack.
+     */
+    virtual ~CothreadImpl() = default;
+
+    /**
+     * Perform a context switch to this cothread.
+     *
+     * The currently executing cothread's state is saved to its buffer, then this cothread's state
+     * is restored.
+     */
+    virtual void switchTo(CothreadImpl *from) = 0;
+
+    /**
+     * Get the stack size of this cothread
+     *
+     * @return Stack size in bytes
+     */
+    virtual size_t getStackSize() const {
+        return this->stack.size() * sizeof(uintptr_t);
+    }
+
+    /**
+     * Get the top (regardless of the direction the stack grows, that is, the first byte allocated
+     * to the stack) of the stack.
+     *
+     * @return Pointer to top of stack
+     */
+    virtual void *getStack() const {
+        return this->stack.data();
+    }
+
+    protected:
+        /// Stack used by this cothread, if any.
+        std::span<uintptr_t> stack;
+};
+
+/**
+ * Allocate the cothread implementation for the currently executing kernel thread.
+ *
+ * This is invoked when no cothread is running on the kernel thread, and is only used to hold the
+ * state of the kernel thread on entry to the first cothread, so it can "resume" the kernel thread.
+ *
+ * @remark Only one definition of this method is allowed; it's typically provided by the platform
+ *         code selected via build configuration.
+ */
+CothreadImpl *AllocKernelThreadWrapper();
+}
+
+#endif

--- a/src/arch/aarch64/AAPCS.S
+++ b/src/arch/aarch64/AAPCS.S
@@ -87,10 +87,9 @@ Aarch64AapcsEntryStub:
 #endif
     mov         x0, x19
 #if defined(__clang__) && defined(__APPLE__)
-    ldr         x16, =__ZN12libcommunism8internal7Aarch6419DereferenceCallInfoEPNS1_8CallInfoE
+    bl  __ZN12libcommunism8internal7Aarch6419DereferenceCallInfoEPNS1_8CallInfoE
 #else
-    ldr         x16, =_ZN12libcommunism8internal7Aarch6419DereferenceCallInfoEPNS1_8CallInfoE
+    bl  _ZN12libcommunism8internal7Aarch6419DereferenceCallInfoEPNS1_8CallInfoE
 #endif
-    br          x16
 
 #endif

--- a/src/arch/aarch64/AAPCS.S
+++ b/src/arch/aarch64/AAPCS.S
@@ -1,11 +1,16 @@
 /// Offset into the Cothread class to get to the "current" stack pointer value.
-#define COTHREAD_OFF_CONTEXT_TOP        (0x0)
+#define COTHREAD_OFF_CONTEXT_TOP        (0x20)
 
 #ifndef __cplusplus
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Define the exported symbol names.
-.global _ZN12libcommunism8internal7Aarch646SwitchEPNS_8CothreadES3_
+#if defined(__clang__) && defined(__APPLE__)
+.global __ZN12libcommunism8internal7Aarch646SwitchEPS1_S2_
+.global _Aarch64AapcsEntryStub
+#else
+.global _ZN12libcommunism8internal7Aarch646SwitchEPS1_S2_
 .global Aarch64AapcsEntryStub
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Performs a context switch between two threads
@@ -28,7 +33,11 @@
 //
 // void libcommunism::internal::Aarch64::Switch(Cothread *from, Cothread *to)
 .balign 0x40
-_ZN12libcommunism8internal7Aarch646SwitchEPNS_8CothreadES3_:
+#if defined(__clang__) && defined(__APPLE__)
+__ZN12libcommunism8internal7Aarch646SwitchEPS1_S2_:
+#else
+_ZN12libcommunism8internal7Aarch646SwitchEPS1_S2_:
+#endif
     // dereference the entry offset address
     ldr         x0, [x0, COTHREAD_OFF_CONTEXT_TOP]
     ldr         x1, [x1, COTHREAD_OFF_CONTEXT_TOP]
@@ -71,9 +80,17 @@ _ZN12libcommunism8internal7Aarch646SwitchEPNS_8CothreadES3_:
 /// proper entry thread entry point.
 ///
 /// extern "C" void Aarch64AapcsEntryStub()
+#if defined(__clang__) && defined(__APPLE__)
+_Aarch64AapcsEntryStub:
+#else
 Aarch64AapcsEntryStub:
+#endif
     mov         x0, x19
+#if defined(__clang__) && defined(__APPLE__)
+    ldr         x16, =__ZN12libcommunism8internal7Aarch6419DereferenceCallInfoEPNS1_8CallInfoE
+#else
     ldr         x16, =_ZN12libcommunism8internal7Aarch6419DereferenceCallInfoEPNS1_8CallInfoE
+#endif
     br          x16
 
 #endif

--- a/src/arch/aarch64/AAPCS.cpp
+++ b/src/arch/aarch64/AAPCS.cpp
@@ -59,11 +59,8 @@ void Aarch64::DeallocStack(void* stack) {
  * @param thread Thread whose stack to prepare
  * @param main Entry point for the cothread
  */
-void Aarch64::Prepare(Cothread *thread, const Cothread::Entry &entry) {
-    static_assert(offsetof(Cothread, stackTop) == COTHREAD_OFF_CONTEXT_TOP, "cothread stack top is invalid");
-
-    // ensure current handle is valid
-    if(!gCurrentHandle) Aarch64::AllocMainCothread();
+void Aarch64::Prepare(Aarch64 *thread, const Entry &entry) {
+    static_assert(offsetof(Aarch64, stackTop) == COTHREAD_OFF_CONTEXT_TOP, "cothread stack top is invalid");
 
     // build the context structure we pass to our "fake" entry point
     auto info = new CallInfo{entry};

--- a/src/arch/aarch64/Common.cpp
+++ b/src/arch/aarch64/Common.cpp
@@ -23,7 +23,6 @@ thread_local std::array<uintptr_t, Aarch64::kMainStackSize> Aarch64::gMainStack;
 /**
  * Allocate a cothread with a private stack.
  *
- *
  * @param entry Method to execute on entry to this cothread
  * @param stackSize Size of the stack to be allocated, in bytes. it should be a multiple of the
  *        machine word size, or specify zero to use the platform default.

--- a/src/arch/aarch64/Common.cpp
+++ b/src/arch/aarch64/Common.cpp
@@ -61,6 +61,14 @@ Aarch64::Aarch64(const Entry &entry, std::span<uintptr_t> _stack) : CothreadImpl
 }
 
 /**
+ * Allocate a cothread placeholder for a kernel thread. This uses a preallocated "stack" to
+ * store the kernel thread's context at the time we switched to the cothread.
+ */
+Aarch64::Aarch64(std::span<uintptr_t> stack) : CothreadImpl(stack), stackTop(stack.data()) {
+}
+
+
+/**
  * Release the stack if we allocated it.
  */
 Aarch64::~Aarch64() {

--- a/src/arch/aarch64/Common.h
+++ b/src/arch/aarch64/Common.h
@@ -2,6 +2,7 @@
 #define ARCH_AARCH64_COMMON_H
 
 #include "CothreadPrivate.h"
+#include "CothreadImpl.h"
 
 #include <array>
 #include <cstddef>
@@ -14,7 +15,9 @@ namespace libcommunism::internal {
  * @remark The context of threads is stored at the top of the allocated stack. Therefore, roughly
  *         0x100 bytes fewer than provided are available as actual program stack.
  */
-struct Aarch64 {
+class Aarch64 final: public CothreadImpl {
+    friend CothreadImpl *libcommunism::AllocKernelThreadWrapper();
+
     /**
      * @brief Information required to make a function call for a cothread's entry point.
      */
@@ -23,63 +26,82 @@ struct Aarch64 {
         Cothread::Entry entry;
     };
 
-    /**
-     * Performs a context switch.
-     *
-     * @remark The implementation of this method is written in assembly.
-     *
-     * @param from Cothread buffer that will receive the current context
-     * @param to Cothread buffer whose context is to be restored
-     */
-    static void Switch(Cothread *from, Cothread *to);
+    public:
+        Aarch64(const Entry &entry, const size_t stackSize = 0);
+        Aarch64(const Entry &entry, std::span<uintptr_t> stack);
+        Aarch64(std::span<uintptr_t> stack) : CothreadImpl(stack) {}
+        ~Aarch64();
 
-    static void AllocMainCothread();
-    static void ValidateStackSize(const size_t size);
-    static void *AllocStack(const size_t bytes);
-    static void DeallocStack(void* stack);
-    static void CothreadReturned();
-    static void DereferenceCallInfo(CallInfo *info);
-    static void Prepare(Cothread *thread, const Cothread::Entry &entry);
+        void switchTo(CothreadImpl *from) override;
 
+    private:
+        static void AllocMainCothread();
+        static void ValidateStackSize(const size_t size);
+        static void *AllocStack(const size_t bytes);
+        static void DeallocStack(void* stack);
+        static void CothreadReturned();
+        static void DereferenceCallInfo(CallInfo *info);
 
-    /**
-     * Size of the reserved region, at the top of the stack, which is reserved for saving the
-     * context of a thread. This is in bytes.
-     */
-    static constexpr const size_t kContextSaveAreaSize{0x100};
+        /**
+         * Given a wrapper structure and initial function to invoke, prepares the context of the
+         * cothread such that it will return to the start of this method.
+         *
+         * @param thread Cothread whose stack frame is to be prepared
+         * @param entry Function to return control to when switching to this cothread
+         */
+        static void Prepare(Aarch64 *thread, const Entry &entry);
 
-    /**
-     * Size of the stack buffer for the "fake" initial cothread, in machine words. This only needs to
-     * be large enough to fit the register frame. This _must_ be a power of two.
-     */
-    static constexpr const size_t kMainStackSize{(kContextSaveAreaSize * 2) / sizeof(uintptr_t)};
+        /**
+         * Performs a context switch.
+         *
+         * @remark This is implemented in platform-specific assembly.
+         *
+         * @param from Cothread buffer that will receive the current context
+         * @param to Cothread buffer whose context is to be restored
+         */
+        static void Switch(Aarch64 *from, Aarch64 *to);
 
-    /**
-     * Requested alignment for stack allocations, in bytes.
-     */
-    static constexpr const size_t kStackAlignment{64};
+    public:
+        /**
+         * Size of the reserved region, at the top of the stack, which is reserved for saving the
+         * context of a thread. This is in bytes.
+         */
+        static constexpr const size_t kContextSaveAreaSize{0x100};
 
-    /**
-     * Platform default size to use for the stack, in bytes, if no size is requested by the caller. We
-     * default to 512K.
-     */
-    static constexpr const size_t kDefaultStackSize{0x80000};
+        /**
+         * Size of the stack buffer for the "fake" initial cothread, in machine words. This only needs to
+         * be large enough to fit the register frame. This _must_ be a power of two.
+         */
+        static constexpr const size_t kMainStackSize{(kContextSaveAreaSize * 2) / sizeof(uintptr_t)};
 
-    /**
-     * Handle for the currently executing cothread in the calling physical thread. This is updated when
-     * switching cothreads, but will be `nullptr` until the first call to `SwitchTo()`.
-     */
-    static thread_local Cothread *gCurrentHandle;
+        /**
+         * Requested alignment for stack allocations, in bytes.
+         */
+        static constexpr const size_t kStackAlignment{64};
 
-    /**
-     * Buffer to hold the state of the kernel thread that executed the first context switch to a
-     * cothread. (In other words, this buffer represents the state of the thread immediately before
-     * starting the first cothread.)
-     *
-     * It does not have to be particularly large, since the stack is actually allocated by the
-     * system already, and this "stack" only holds the register state.
-     */
-    static thread_local std::array<uintptr_t, kMainStackSize> gMainStack;
+        /**
+         * Platform default size to use for the stack, in bytes, if no size is requested by the caller. We
+         * default to 512K.
+         */
+        static constexpr const size_t kDefaultStackSize{0x80000};
+
+    private:
+        /**
+         * Buffer to hold the state of the kernel thread that executed the first context switch to
+         * a cothread. (In other words, this buffer represents the state of the thread immediately
+         * before starting the first cothread.)
+         *
+         * It does not have to be particularly large, since the stack is actually allocated by the
+         * system already, and this "stack" only holds the register state.
+         */
+        static thread_local std::array<uintptr_t, kMainStackSize> gMainStack;
+
+    private:
+        /// When set, the stack was allocated by us and must be freed on release
+        bool ownsStack{false};
+
+        /// Pointer to the top of the stack, where the thread's state is stored
+        void *stackTop{nullptr};
 };
 }
 

--- a/src/arch/aarch64/Common.h
+++ b/src/arch/aarch64/Common.h
@@ -29,7 +29,7 @@ class Aarch64 final: public CothreadImpl {
     public:
         Aarch64(const Entry &entry, const size_t stackSize = 0);
         Aarch64(const Entry &entry, std::span<uintptr_t> stack);
-        Aarch64(std::span<uintptr_t> stack) : CothreadImpl(stack) {}
+        Aarch64(std::span<uintptr_t> stack);
         ~Aarch64();
 
         void switchTo(CothreadImpl *from) override;

--- a/src/arch/amd64/Common.cpp
+++ b/src/arch/amd64/Common.cpp
@@ -16,49 +16,54 @@
 using namespace libcommunism;
 using namespace libcommunism::internal;
 
-thread_local Cothread *Amd64::gCurrentHandle{nullptr};
 thread_local std::array<uintptr_t, Amd64::kMainStackSize> Amd64::gMainStack;
 
-
-
-Cothread *Cothread::Current() {
-    if(!Amd64::gCurrentHandle) Amd64::AllocMainCothread();
-    return Amd64::gCurrentHandle;
-}
-
 /**
- * Allocates a cothread including a context region of the specified size.
+ * Allocates an amd64 thread, allocating its stack.
+ *
+ *
+ * @param entry Method to execute on entry to this cothread
+ * @param stackSize Size of the stack to be allocated, in bytes. it should be a multiple of the
+ *        machine word size, or specify zero to use the platform default.
+ *
+ * @throw std::runtime_error If the memory for the cothread could not be allocated.
+ * @throw std::runtime_error If the provided stack size is invalid
  */
-Cothread::Cothread(const Entry &entry, const size_t stackSize) {
+Amd64::Amd64(const Entry &entry, const size_t stackSize) : CothreadImpl(entry, stackSize) {
     void *buf{nullptr};
 
     // round down stack size to ensure it's aligned before allocating it
-    auto allocSize = stackSize & ~(Amd64::kStackAlignment - 1);
-    allocSize = allocSize ? allocSize : Amd64::kDefaultStackSize;
+    auto allocSize = stackSize & ~(kStackAlignment - 1);
+    allocSize = allocSize ? allocSize : kDefaultStackSize;
 
-    buf = Amd64::AllocStack(allocSize);
+    buf = AllocStack(allocSize);
 
     // create it as if we had provided the memory in the first place
     this->stack = {reinterpret_cast<uintptr_t *>(buf), allocSize / sizeof(uintptr_t)};
-    this->flags = Cothread::Flags::OwnsStack;
+    this->ownsStack = true;
 
-    Amd64::Prepare(this, entry);
+    Prepare(this, entry);
 }
 
 /**
- * Allocates a cothread with an existing region of memory to back its stack.
+ * Allocates and amd64 cothread with an already provided stack.
+ *
+ * @param entry Method to execute on entry to this cothread
+ * @param stack Buffer to use as the stack of the cothread
+ *
+ * @throw std::runtime_error If the provided stack is invalid
  */
-Cothread::Cothread(const Entry &entry, std::span<uintptr_t> _stack) : stack(_stack) {
-    Amd64::ValidateStackSize(_stack.size() * sizeof(uintptr_t));
-    Amd64::Prepare(this, entry);
+Amd64::Amd64(const Entry &entry, std::span<uintptr_t> _stack) : CothreadImpl(entry, _stack) {
+    ValidateStackSize(_stack.size() * sizeof(uintptr_t));
+    Prepare(this, entry);
 }
 
 /**
- * Deallocates a cothread. This releases the underlying stack if we allocated it.
+ * Release the stack if we allocated it.
  */
-Cothread::~Cothread() {
-    if(static_cast<uintptr_t>(this->flags) & static_cast<uintptr_t>(Flags::OwnsStack)) {
-        Amd64::DeallocStack(this->stack.data());
+Amd64::~Amd64() {
+    if(this->ownsStack) {
+        DeallocStack(this->stack.data());
     }
 }
 
@@ -67,28 +72,15 @@ Cothread::~Cothread() {
  *
  * The state of the caller is stored on the stack of the currently active thread.
  */
-void Cothread::switchTo() {
-    auto from = Amd64::gCurrentHandle;
-    Amd64::gCurrentHandle = this;
-    Amd64::Switch(from, this);
-}
-
-/**
- * Allocates the current physical (kernel) thread's Cothread object.
- *
- * @note This will leak the associated cothread object, unless the caller stores it somewhere and
- *       ensures they deallocate it later when the underlying kernel thread is destroyed.
- */
-void Amd64::AllocMainCothread() {
-    auto main = new Cothread(gMainStack, gMainStack.data() + Amd64::kMainStackSize);
-    gCurrentHandle = main;
+void Amd64::switchTo(CothreadImpl *from) {
+    Switch(static_cast<Amd64 *>(from), this);
 }
 
 /**
  * The currently running cothread returned from its main function. This is very naughty behavior.
  */
 void Amd64::CothreadReturned() {
-    gReturnHandler(gCurrentHandle);
+    gReturnHandler(Cothread::Current());
 }
 
 /**
@@ -101,3 +93,14 @@ void Amd64::DereferenceCallInfo(CallInfo *info) {
     delete info;
 }
 
+
+
+/**
+ * Allocates the current physical (kernel) thread's Cothread object.
+ *
+ * @note This will leak the associated cothread object, unless the caller stores it somewhere and
+ *       ensures they deallocate it later when the underlying kernel thread is destroyed.
+ */
+CothreadImpl *libcommunism::AllocKernelThreadWrapper() {
+    return new Amd64(Amd64::gMainStack);
+}

--- a/src/arch/amd64/Common.h
+++ b/src/arch/amd64/Common.h
@@ -2,157 +2,166 @@
 #define ARCH_AMD64_COMMON_H
 
 #include "CothreadPrivate.h"
+#include "CothreadImpl.h"
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
+#include <span>
 
 namespace libcommunism::internal {
 /**
  * @brief Architecture specific methods for working with cothreads on amd64 based systems.
  */
-struct Amd64 {
-    /**
-     * @brief Information required to make a function call for a cothread's entry point.
-     */
-    struct CallInfo {
-        /// Entry point of the cothread
-        Cothread::Entry entry;
-    };
+class Amd64 final: public CothreadImpl {
+    friend CothreadImpl *libcommunism::AllocKernelThreadWrapper();
 
-    /**
-     * Allocates the current physical (kernel) thread's Cothread object.
-     *
-     * @note This will leak the associated cothread object, unless the caller stores it somewhere
-     *       and ensures they deallocate it later when the underlying kernel thread is destroyed.
-     */
-    static void AllocMainCothread();
+    private:
+        /**
+         * @brief Information required to make a function call for a cothread's entry point.
+         */
+        struct CallInfo {
+            /// Entry point of the cothread
+            Cothread::Entry entry;
+        };
 
-    /**
-     * Ensures the provided stack size is valid.
-     *
-     * @param size Size of stack, in bytes.
-     *
-     * @throw std::runtime_error Stack size is invalid (misaligned, too small, etc.)
-     */
-    static void ValidateStackSize(const size_t size);
+    public:
+        Amd64(const Entry &entry, const size_t stackSize = 0);
+        Amd64(const Entry &entry, std::span<uintptr_t> stack);
+        Amd64(std::span<uintptr_t> stack) : CothreadImpl(stack) {}
+        ~Amd64();
 
-    /**
-     * Allocates memory for a stack that's the given number of bytes in size.
-     *
-     * @remark If required (for page alignment, for example) the size may be rounded up.
-     *
-     * @param bytes Size of the stack memory, in bytes.
-     * 
-     * @return Pointer to the _top_ of allocated stack
-     */
-    static void* AllocStack(const size_t bytes);
+        void switchTo(CothreadImpl *from) override;
 
-    /**
-     * Releases previously allocated stack memory.
-     * 
-     * @param stack Pointer to the top of previously allocated stack.
-     * 
-     * @throw std::runtime_error If deallocating stack fails (invalid pointer)
-     */
-    static void DeallocStack(void* stack);
+    private:
+        /**
+         * Ensures the provided stack size is valid.
+         *
+         * @param size Size of stack, in bytes.
+         *
+         * @throw std::runtime_error Stack size is invalid (misaligned, too small, etc.)
+         */
+        static void ValidateStackSize(const size_t size);
 
-    /**
-     * Invoked when the main method of a cothread returns.
-     */
-    static void CothreadReturned();
+        /**
+         * Allocates memory for a stack that's the given number of bytes in size.
+         *
+         * @remark If required (for page alignment, for example) the size may be rounded up.
+         *
+         * @param bytes Size of the stack memory, in bytes.
+         * 
+         * @return Pointer to the _top_ of allocated stack
+         */
+        static void* AllocStack(const size_t bytes);
 
-    /**
-     * Performs the call described inside a call info structure.
-     *
-     * @param info Pointer to the call info structure; it's deleted once the call returns.
-     */
-    static void DereferenceCallInfo(CallInfo *info);
+        /**
+         * Releases previously allocated stack memory.
+         * 
+         * @param stack Pointer to the top of previously allocated stack.
+         * 
+         * @throw std::runtime_error If deallocating stack fails (invalid pointer)
+         */
+        static void DeallocStack(void* stack);
 
-    /**
-     * Given a wrapper structure and initial function to invoke, prepares the context of the
-     * cothread such that it will return to the start of this method.
-     *
-     * @param thread Cothread whose stack frame is to be prepared
-     * @param entry Function to return control to when switching to this cothread
-     */
-    static void Prepare(Cothread *thread, const Cothread::Entry &entry);
+        /**
+         * Invoked when the main method of a cothread returns.
+         */
+        static void CothreadReturned();
 
-    /**
-     * Performs a context switch.
-     *
-     * @remark The implementation of this method is written in assembly and varies slightly depending
-     *         on the calling convention of the platform (System V vs. Windows.)
-     *
-     * @param from Cothread buffer that will receive the current context
-     * @param to Cothread buffer whose context is to be restored
-     */
-    static void Switch(Cothread *from, Cothread *to);
+        /**
+         * Performs the call described inside a call info structure.
+         *
+         * @param info Pointer to the call info structure; it's deleted once the call returns.
+         */
+        static void DereferenceCallInfo(CallInfo *info);
 
-    /**
-     * Pops two arguments off the stack (the entry point and its context argument) and invokes the
-     * entry point.
-     *
-     * @remark The implementation of this method is written in assembly and varies slightly depending
-     *         on the calling convention of the platform (System V vs. Windows.)
-     *
-     * @remark The arguments are implicit; they reside on the stack when this method is invoked.
-     */
-    static void JumpToEntry(/* void (*func)(void *), void *ctx */);
+        /**
+         * Given a wrapper structure and initial function to invoke, prepares the context of the
+         * cothread such that it will return to the start of this method.
+         *
+         * @param thread Cothread whose stack frame is to be prepared
+         * @param entry Function to return control to when switching to this cothread
+         */
+        static void Prepare(Amd64 *thread, const Entry &entry);
 
-    /**
-     * Stub method that fixes the stack alignment before invoking the error handler for a cothread
-     * that returned from its main method.
-     */
-    static void EntryReturnedStub();
+        /**
+         * Performs a context switch.
+         *
+         * @remark The implementation of this method is written in assembly and varies slightly depending
+         *         on the calling convention of the platform (System V vs. Windows.)
+         *
+         * @param from Cothread buffer that will receive the current context
+         * @param to Cothread buffer whose context is to be restored
+         */
+        static void Switch(Amd64 *from, Amd64 *to);
 
+        /**
+         * Pops two arguments off the stack (the entry point and its context argument) and invokes the
+         * entry point.
+         *
+         * @remark The implementation of this method is written in assembly and varies slightly depending
+         *         on the calling convention of the platform (System V vs. Windows.)
+         *
+         * @remark The arguments are implicit; they reside on the stack when this method is invoked.
+         */
+        static void JumpToEntry(/* void (*func)(void *), void *ctx */);
 
-    /**
-     * Number of registers saved by the cothread swap code. This is used to correctly build the stack
-     * frames during initialization.
-     */
-    static const size_t kNumSavedRegisters;
+        /**
+         * Stub method that fixes the stack alignment before invoking the error handler for a cothread
+         * that returned from its main method.
+         */
+        static void EntryReturnedStub();
 
-    /**
-     * Size of the stack buffer for the "fake" initial cothread, in machine words. This only needs to
-     * be large enough to fit the register stack frame. This _must_ be a power of two.
-     *
-     * It must be sufficiently large to store the callee-saved general purpose registers, as well as
-     * all of the SSE registers on Windows.
-     */
-    static constexpr const size_t kMainStackSize{64};
+    public:
+        /**
+         * Number of registers saved by the cothread swap code. This is used to correctly build the stack
+         * frames during initialization.
+         */
+        static const size_t kNumSavedRegisters;
 
-    /**
-     * Requested alignment for stack allocations.
-     *
-     * This is set to 64 bytes for cache line alignment. On amd64, the stack should always be at least
-     * 16 byte aligned (for SSE quantities).
-     */
-    static constexpr const size_t kStackAlignment{64};
+        /**
+         * Size of the stack buffer for the "fake" initial cothread, in machine words. This only needs to
+         * be large enough to fit the register stack frame. This _must_ be a power of two.
+         *
+         * It must be sufficiently large to store the callee-saved general purpose registers, as well as
+         * all of the SSE registers on Windows.
+         */
+        static constexpr const size_t kMainStackSize{64};
 
-    /**
-     * Platform default size to use for the stack, in bytes, if no size is requested by the caller. We
-     * default to 512K.
-     */
-    static constexpr const size_t kDefaultStackSize{0x80000};
+        /**
+         * Requested alignment for stack allocations.
+         *
+         * This is set to 64 bytes for cache line alignment. On amd64, the stack should always be at least
+         * 16 byte aligned (for SSE quantities).
+         */
+        static constexpr const size_t kStackAlignment{64};
 
-    /**
-     * Handle for the currently executing cothread in the calling physical thread. This is updated when
-     * switching cothreads, but will be `nullptr` until the first call to `SwitchTo()`.
-     */
-    static thread_local Cothread *gCurrentHandle;
+        /**
+         * Platform default size to use for the stack, in bytes, if no size is requested by the caller. We
+         * default to 512K.
+         */
+        static constexpr const size_t kDefaultStackSize{0x80000};
 
-    /**
-     * Pseudo-stack to use for the "main" cothread, i.e. the native kernel thread executing before
-     * a cothread is ever switched to it.
-     *
-     * This buffer receives the stack frame of the context of the thread on the first invocation to
-     * SwitchTo(). When invoking the Current() method before executing a real cothread, the
-     * returned Cothread will correspond to this buffer.
-     *
-     * It does not have to be particularly large, since the stack is actually allocated by the
-     * system already, and this "stack" only holds the register state.
-     */
-    static thread_local std::array<uintptr_t, kMainStackSize> gMainStack;
+    private:
+        /**
+         * Pseudo-stack to use for the "main" cothread, i.e. the native kernel thread executing before
+         * a cothread is ever switched to it.
+         *
+         * This buffer receives the stack frame of the context of the thread on the first invocation to
+         * SwitchTo(). When invoking the Current() method before executing a real cothread, the
+         * returned Cothread will correspond to this buffer.
+         *
+         * It does not have to be particularly large, since the stack is actually allocated by the
+         * system already, and this "stack" only holds the register state.
+         */
+        static thread_local std::array<uintptr_t, kMainStackSize> gMainStack;
+
+    private:
+        /// When set, the stack was allocated by us and must be freed on release
+        bool ownsStack{false};
+
+        /// Pointer to the top of the stack, where the thread's state is stored
+        void *stackTop{nullptr};
 };
 }
 

--- a/src/arch/amd64/SysV.S
+++ b/src/arch/amd64/SysV.S
@@ -1,6 +1,6 @@
 // Define the offsets into the `cothread_amd64::Wrapper` structure. These _MUST_ match to the actual
 // offsets of the field in the struct.
-#define COTHREAD_OFF_CONTEXT_TOP        (0x0)
+#define COTHREAD_OFF_CONTEXT_TOP        (0x20)
 
 #ifndef __cplusplus
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -8,11 +8,11 @@
 // leading underscore, but macOS requires it. We assume that clang is the only compiler that needs
 // this treatment.
 #ifdef __clang__
-.global __ZN12libcommunism8internal5Amd646SwitchEPNS_8CothreadES3_
+.global __ZN12libcommunism8internal5Amd646SwitchEPS1_S2_
 .global __ZN12libcommunism8internal5Amd6411JumpToEntryEv
 .global __ZN12libcommunism8internal5Amd6417EntryReturnedStubEv
 #else
-.global _ZN12libcommunism8internal5Amd646SwitchEPNS_8CothreadES3_
+.global _ZN12libcommunism8internal5Amd646SwitchEPS1_S2_
 .global _ZN12libcommunism8internal5Amd6411JumpToEntryEv
 .global _ZN12libcommunism8internal5Amd6417EntryReturnedStubEv
 #endif
@@ -28,9 +28,9 @@
 // void libcommunism::internal::Amd64::Switch(Cothread *from, Cothread *to)
 .balign 0x40
 #ifdef __clang__
-__ZN12libcommunism8internal5Amd646SwitchEPNS_8CothreadES3_:
+__ZN12libcommunism8internal5Amd646SwitchEPS1_S2_:
 #else
-_ZN12libcommunism8internal5Amd646SwitchEPNS_8CothreadES3_:
+_ZN12libcommunism8internal5Amd646SwitchEPS1_S2_:
 #endif
     // save current state to stack and record the stack frame
     push        %rbp

--- a/src/arch/amd64/SysV.S
+++ b/src/arch/amd64/SysV.S
@@ -7,7 +7,7 @@
 // Define the proper symbol names, based on what compiler we have. For GNU, we do not need an extra
 // leading underscore, but macOS requires it. We assume that clang is the only compiler that needs
 // this treatment.
-#ifdef __clang__
+#if defined(__clang__) && defined(__APPLE__)
 .global __ZN12libcommunism8internal5Amd646SwitchEPS1_S2_
 .global __ZN12libcommunism8internal5Amd6411JumpToEntryEv
 .global __ZN12libcommunism8internal5Amd6417EntryReturnedStubEv
@@ -27,7 +27,7 @@
 // under the System V ABI.
 // void libcommunism::internal::Amd64::Switch(Cothread *from, Cothread *to)
 .balign 0x40
-#ifdef __clang__
+#if defined(__clang__) && defined(__APPLE__)
 __ZN12libcommunism8internal5Amd646SwitchEPS1_S2_:
 #else
 _ZN12libcommunism8internal5Amd646SwitchEPS1_S2_:
@@ -59,7 +59,7 @@ _ZN12libcommunism8internal5Amd646SwitchEPS1_S2_:
 // This pulls the arguments off the stack, since that's the only real nice way we can pass
 // information to this function (the registers aren't necessarily initialized here)
 // void libcommunism::internal::Amd64::JumpToEntry(void)
-#ifdef __clang__
+#if defined(__clang__) && defined(__APPLE__)
 __ZN12libcommunism8internal5Amd6411JumpToEntryEv:
 #else
 _ZN12libcommunism8internal5Amd6411JumpToEntryEv:
@@ -74,7 +74,7 @@ _ZN12libcommunism8internal5Amd6411JumpToEntryEv:
 // we invoke the library handler.
 //
 // void libcommunism::internal::Amd64::EntryReturnedStub(void)
-#ifdef __clang__
+#if defined(__clang__) && defined(__APPLE__)
 __ZN12libcommunism8internal5Amd6417EntryReturnedStubEv:
 #else
 _ZN12libcommunism8internal5Amd6417EntryReturnedStubEv:
@@ -84,7 +84,7 @@ _ZN12libcommunism8internal5Amd6417EntryReturnedStubEv:
     mov         %rsp, %rbp
 
     // libcommunism::internal::Amd64::CothreadReturned()
-#ifdef __clang__
+#if defined(__clang__) && defined(__APPLE__)
     call        __ZN12libcommunism8internal5Amd6416CothreadReturnedEv
 #else
     call        _ZN12libcommunism8internal5Amd6416CothreadReturnedEv

--- a/src/arch/amd64/SysV.cpp
+++ b/src/arch/amd64/SysV.cpp
@@ -77,11 +77,8 @@ void Amd64::DeallocStack(void* stack) {
  * @param wrap Wrapper structure defining the cothread
  * @param main Entry point for the cothread
  */
-void Amd64::Prepare(Cothread *wrap, const Cothread::Entry &entry) {
-    static_assert(offsetof(Cothread, stackTop) == COTHREAD_OFF_CONTEXT_TOP, "cothread stack top is invalid");
-
-    // ensure current handle is valid
-    if(!gCurrentHandle) Amd64::AllocMainCothread();
+void Amd64::Prepare(Amd64 *wrap, const Entry &entry) {
+    static_assert(offsetof(Amd64, stackTop) == COTHREAD_OFF_CONTEXT_TOP, "cothread stack top is invalid");
 
     // build the context structure we pass to our "fake" entry point
     auto info = new CallInfo{entry};

--- a/src/arch/amd64/Windows.asm
+++ b/src/arch/amd64/Windows.asm
@@ -1,6 +1,6 @@
 .code
 
-?CothreadReturned@Amd64@internal@libcommunism@@SAXXZ    proto
+?CothreadReturned@Amd64@internal@libcommunism@@CAXXZ    proto
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; This performs a context switch between two cothreads.
@@ -9,7 +9,7 @@
 ; -   to (RDX)
 ;
 ; void libcommunism::internal::Amd64::Switch(Cothread *from, Cothread *to)
-?Switch@Amd64@internal@libcommunism@@SAXPEAVCothread@3@0@Z PROC
+?Switch@Amd64@internal@libcommunism@@CAXPEAV123@0@Z PROC
     ; save integer state
     push    RBP
     push    RBX
@@ -65,7 +65,7 @@
     ; return to caller
     ret
 
-?Switch@Amd64@internal@libcommunism@@SAXPEAVCothread@3@0@Z ENDP
+?Switch@Amd64@internal@libcommunism@@CAXPEAV123@0@Z ENDP
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Pops two fields off the stack (for the entry point and its context) then jumps to that
@@ -75,24 +75,24 @@
 ; that we don't have.
 ;
 ; void libcommunism::internal::Amd64::JumpToEntry(void)
-?JumpToEntry@Amd64@internal@libcommunism@@SAXXZ PROC
+?JumpToEntry@Amd64@internal@libcommunism@@CAXXZ PROC
     pop     RAX
     pop     RCX
     jmp     RAX
-?JumpToEntry@Amd64@internal@libcommunism@@SAXXZ ENDP
+?JumpToEntry@Amd64@internal@libcommunism@@CAXXZ ENDP
     
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Fixes the stack frame and calls the C++ routine indicating that we've exited a cothread's main
 ; routine.
 ;
 ; void libcommunism::internal::Amd64::EntryReturnedStub(void)
-?EntryReturnedStub@Amd64@internal@libcommunism@@SAXXZ PROC
+?EntryReturnedStub@Amd64@internal@libcommunism@@CAXXZ PROC
     sub     RSP, 8h
     push    RBP
     mov     RBP, RSP
     
     sub     RSP, 20h
-    call    ?CothreadReturned@Amd64@internal@libcommunism@@SAXXZ
-?EntryReturnedStub@Amd64@internal@libcommunism@@SAXXZ ENDP
+    call    ?CothreadReturned@Amd64@internal@libcommunism@@CAXXZ
+?EntryReturnedStub@Amd64@internal@libcommunism@@CAXXZ ENDP
 
 end

--- a/src/arch/amd64/Windows.asm
+++ b/src/arch/amd64/Windows.asm
@@ -34,10 +34,10 @@
     sub     RSP, 0A0h
 
     ; save stack
-    mov     [RCX+0h], RSP
+    mov     [RCX+20h], RSP
 
     ; restore stack
-    mov     RSP, [RDX+0h]
+    mov     RSP, [RDX+20h]
 
     ; restore SSE state
     add     RSP, 0A0h

--- a/src/arch/amd64/Windows.cpp
+++ b/src/arch/amd64/Windows.cpp
@@ -78,11 +78,8 @@ void Amd64::DeallocStack(void* stack) {
  * @param wrap Wrapper structure defining the cothread
  * @param main Entry point for the cothread
  */
-void Amd64::Prepare(Cothread* wrap, const Cothread::Entry& entry) {
-    static_assert(offsetof(Cothread, stackTop) == COTHREAD_OFF_CONTEXT_TOP, "cothread stack top is invalid");
-
-    // ensure current handle is valid
-    if (!gCurrentHandle) Amd64::AllocMainCothread();
+void Amd64::Prepare(Amd64 *wrap, const Cothread::Entry& entry) {
+    static_assert(offsetof(Amd64, stackTop) == COTHREAD_OFF_CONTEXT_TOP, "cothread stack top is invalid");
 
     // build the context structure we pass to our "fake" entry point
     auto info = new CallInfo{ entry };

--- a/src/arch/setjmp/SetJmp.h
+++ b/src/arch/setjmp/SetJmp.h
@@ -2,6 +2,7 @@
 #define ARCH_SETJMP_SETJMP_H
 
 #include "CothreadPrivate.h"
+#include "CothreadImpl.h"
 
 #include <array>
 #include <cstddef>
@@ -21,104 +22,114 @@ namespace libcommunism::internal {
  * @remark Since signals are a per-process resource, allocation of cothreads effectively becomes
  *         serialized to ensure safety.
  */
-struct SetJmp {
-    /**
-     * @brief Context structure passed to the entry point of a setjmp based cothread
-     */
-    struct EntryContext {
-        /// Cothread that is being created
-        Cothread *thread{nullptr};
-        /// Entry point of the cothread
-        Cothread::Entry entry;
-        /// Initializes a context struct with the given entry point.
-        EntryContext(Cothread *_thread, const Cothread::Entry &_entry) : thread(_thread),
-            entry(_entry) {}
-    };
+class SetJmp final: public CothreadImpl {
+    friend CothreadImpl *libcommunism::AllocKernelThreadWrapper();
 
-    /**
-     * Returns a pointer to the `sigjmp_buf` structure for a given cooperative thread.
-     *
-     * It's stored at the top of its stack buffer. The actual stack available to the program will
-     * be reduced accordingly, but it is still possible for the program to overflow into this
-     * structure and wreak havoc.
-     *
-     * @param thread Thread whose setjmp buffer to retrieve
-     *
-     * @return Thread's setjmp, in the stack allocation.
-     */
-    static auto JmpBufFor(Cothread *thread) {
-        return reinterpret_cast<sigjmp_buf *>(thread->stack.data());
-    }
+    public:
+        SetJmp(const Entry &entry, const size_t stackSize = 0);
+        SetJmp(const Entry &entry, std::span<uintptr_t> stack);
+        SetJmp(std::span<uintptr_t> stack) : CothreadImpl(stack) {}
+        ~SetJmp();
 
-    static void AllocMainCothread();
-    static void Prepare(Cothread *thread, const Cothread::Entry &entry);
-    static void InvokeCothreadDidReturnHandler(Cothread *from);
-    static void SignalHandlerSetupThunk(int);
+        void switchTo(CothreadImpl *from) override;
 
+    private:
+        /**
+         * @brief Context structure passed to the entry point of a setjmp based cothread
+         */
+        struct EntryContext {
+            /// Implementation for this cothread
+            SetJmp *impl{nullptr};
 
-    /**
-     * Requested alignment for stack allocations.
-     *
-     * 64 bytes is the most stringent alignment requirements we should probably encounter in the
-     * real world (one cache line on most systems) and alignment doesn't result in _that_ much
-     * overhead so this is fine.
-     *
-     * @remark This must be a power of 2.
-     */
-    static constexpr const size_t kStackAlignment{64};
+            /// Entry point of the cothread
+            Cothread::Entry entry;
+            /// Initializes a context struct with the given entry point.
+            EntryContext(SetJmp *_impl, const Cothread::Entry &_entry) : impl(_impl),
+                entry(_entry) {}
+        };
 
-    /**
-     * Size of the stack buffer for the "fake" initial cothread, in machine words. This only needs to
-     * be large enough to fit the register stack frame. This _must_ be a power of two.
-     *
-     * It must be sufficiently large to fit an sigjmp_buf it.
-     */
-    static constexpr const size_t kMainStackSize{512};
+        /**
+         * Returns a pointer to the `sigjmp_buf` structure for a given cooperative thread.
+         *
+         * It's stored at the top of its stack buffer. The actual stack available to the program will
+         * be reduced accordingly, but it is still possible for the program to overflow into this
+         * structure and wreak havoc.
+         *
+         * @param thread Thread whose setjmp buffer to retrieve
+         *
+         * @return Thread's setjmp, in the stack allocation.
+         */
+        static auto JmpBufFor(CothreadImpl *thread) {
+            return reinterpret_cast<sigjmp_buf *>(static_cast<SetJmp *>(thread)->stack.data());
+        }
 
-    /**
-     * Default stack size in bytes, if none was requested by the caller. Since this implementation
-     * may work on different width architectures, we define this as 64K worth of machine words.
-     */
-    static constexpr const size_t kDefaultStackSize{sizeof(uintptr_t) * 0x10000};
+        static void AllocMainCothread();
+        static void InvokeCothreadDidReturnHandler(Cothread *from);
+        static void SignalHandlerSetupThunk(int);
 
+        void Prepare(SetJmp *thread, const Cothread::Entry &entry);
 
-    /**
-     * Handle for the currently executing cothread in the calling physical thread. This is updated when
-     * switching cothreads, but will be `nullptr` until the first call to `SwitchTo()`.
-     */
-    static thread_local Cothread *gCurrentHandle;
+    public:
+        /**
+         * Requested alignment for stack allocations.
+         *
+         * 64 bytes is the most stringent alignment requirements we should probably encounter in the
+         * real world (one cache line on most systems) and alignment doesn't result in _that_ much
+         * overhead so this is fine.
+         *
+         * @remark This must be a power of 2.
+         */
+        static constexpr const size_t kStackAlignment{64};
 
-    /**
-     * Pseudo-stack to use for the "main" cothread, i.e. the native kernel thread executing before
-     * a cothread is ever switched to it.
-     *
-     * This buffer receives the stack frame of the context of the thread on the first invocation to
-     * SwitchTo(). When invoking the Current() method before executing a real cothread, the
-     * returned Cothread will correspond to this buffer.
-     *
-     * It does not have to be particularly large, since the stack is actually allocated by the
-     * system already, and this "stack" only holds the `sigjmp_buf`.
-     */
-    static thread_local std::array<uintptr_t, kMainStackSize> gMainStack;
+        /**
+         * Size of the stack buffer for the "fake" initial cothread, in machine words. This only needs to
+         * be large enough to fit the register stack frame. This _must_ be a power of two.
+         *
+         * It must be sufficiently large to fit an sigjmp_buf it.
+         */
+        static constexpr const size_t kMainStackSize{512};
 
+        /**
+         * Default stack size in bytes, if none was requested by the caller. Since this implementation
+         * may work on different width architectures, we define this as 64K worth of machine words.
+         */
+        static constexpr const size_t kDefaultStackSize{sizeof(uintptr_t) * 0x10000};
 
-    /**
-     * Global variable indicating the context of the current cothread whose state buffer is to be
-     * initialized. This is consulted in the signal handler to find the thread's actual entry
-     * point.
-     */
-    static EntryContext *gCurrentlyPreparing;
+    private:
+        /**
+         * Pseudo-stack to use for the "main" cothread, i.e. the native kernel thread executing before
+         * a cothread is ever switched to it.
+         *
+         * This buffer receives the stack frame of the context of the thread on the first invocation to
+         * SwitchTo(). When invoking the Current() method before executing a real cothread, the
+         * returned Cothread will correspond to this buffer.
+         *
+         * It does not have to be particularly large, since the stack is actually allocated by the
+         * system already, and this "stack" only holds the `sigjmp_buf`.
+         */
+        static thread_local std::array<uintptr_t, kMainStackSize> gMainStack;
 
-    /**
-     * Because the signals are shared between all threads in a process, including the associated
-     * signal stacks, it's possible that multiple threads attempting to be prepared simultaneously
-     * would cause issues.
-     *
-     * Therefore, this lock is taken for the duration of signal based operations (that is, the
-     * entire time between saving the current signal handler, installing our custom ones, raising
-     * the signal, and then restoring the old h andlers) needed to initialize the context buffer.
-     */
-    static std::mutex gSignalLock;
+        /**
+         * Global variable indicating the context of the current cothread whose state buffer is to be
+         * initialized. This is consulted in the signal handler to find the thread's actual entry
+         * point.
+         */
+        static EntryContext *gCurrentlyPreparing;
+
+        /**
+         * Because the signals are shared between all threads in a process, including the associated
+         * signal stacks, it's possible that multiple threads attempting to be prepared simultaneously
+         * would cause issues.
+         *
+         * Therefore, this lock is taken for the duration of signal based operations (that is, the
+         * entire time between saving the current signal handler, installing our custom ones, raising
+         * the signal, and then restoring the old h andlers) needed to initialize the context buffer.
+         */
+        static std::mutex gSignalLock;
+
+    private:
+        /// When set, the stack was allocated by us and must be freed on release
+        bool ownsStack{false};
 };
 }
 

--- a/src/arch/ucontext/UContext.h
+++ b/src/arch/ucontext/UContext.h
@@ -2,6 +2,7 @@
 #define ARCH_UCONTEXT_UCONTEXT_H
 
 #include "CothreadPrivate.h"
+#include "CothreadImpl.h"
 
 #include <array>
 #include <cstddef>
@@ -9,6 +10,7 @@
 #include <mutex>
 #include <unordered_map>
 
+#define _XOPEN_SOURCE
 #include <ucontext.h>
 
 namespace libcommunism::internal {
@@ -28,104 +30,113 @@ namespace libcommunism::internal {
  * @note Since ucontext has been deprecated since the 2008 revision of POSIX, this may stop
  *       working (or not even be supported to begin with) on any given platform in the future.
  */
-struct UContext {
-    /**
-     * @brief Context structure passed to the entry point of an ucontext
-     */
-    struct Context {
-        /// Entry point of the cothread
-        Cothread::Entry entry;
+class UContext final: public CothreadImpl {
+    friend CothreadImpl *libcommunism::AllocKernelThreadWrapper();
 
-        /// Initializes a context struct with the given entry point.
-        Context(const Cothread::Entry &_entry) : entry(_entry) {}
-    };
+    public:
+        UContext(const Entry &entry, const size_t stackSize = 0);
+        UContext(const Entry &entry, std::span<uintptr_t> stack);
+        UContext(std::span<uintptr_t> stack) : CothreadImpl(stack) {}
+        ~UContext();
 
-    /**
-     * Returns a pointer to the `ucontext_t` structure for a given cooperative thread.
-     *
-     * It's stored at the top of its stack buffer. The actual stack available to the program will
-     * be reduced accordingly, but it is still possible for the program to overflow into this
-     * structure and wreak havoc.
-     *
-     * @param thread Thread whose user context struct to retrieve
-     *
-     * @return Thread's user context, in the stack allocation.
-     */
-    static ucontext_t *ContextFor(Cothread *thread) {
-        return reinterpret_cast<ucontext_t *>(thread->stack.data());
-    }
+        void switchTo(CothreadImpl *from) override;
 
-    static void AllocMainCothread();
-    static void Prepare(Cothread *thread, const Cothread::Entry &entry);
-    static void EntryStub(int id);
-    static void InvokeCothreadDidReturnHandler(Cothread *from);
+    private:
+        /**
+         * @brief Context structure passed to the entry point of an ucontext
+         */
+        struct Context {
+            /// Entry point of the cothread
+            Cothread::Entry entry;
 
-    /**
-     * Requested alignment for stack allocations.
-     *
-     * 64 bytes is the most stringent alignment requirements we should probably encounter in the
-     * real world (one cache line on most systems) and alignment doesn't result in _that_ much
-     * overhead so this is fine.
-     *
-     * @remark This must be a power of 2.
-     */
-    static constexpr const size_t kStackAlignment{64};
+            /// Initializes a context struct with the given entry point.
+            Context(const Cothread::Entry &_entry) : entry(_entry) {}
+        };
 
-    /**
-     * Size of the stack buffer for the "fake" initial cothread, in machine words. This only needs to
-     * be large enough to fit the register stack frame. This _must_ be a power of two.
-     *
-     * It must be sufficiently large to fit an ucontext_t in it.
-     */
-    static constexpr const size_t kMainStackSize{128};
+        /**
+         * Returns a pointer to the `ucontext_t` structure for a given cooperative thread.
+         *
+         * It's stored at the top of its stack buffer. The actual stack available to the program will
+         * be reduced accordingly, but it is still possible for the program to overflow into this
+         * structure and wreak havoc.
+         *
+         * @param thread Thread whose user context struct to retrieve
+         *
+         * @return Thread's user context, in the stack allocation.
+         */
+        static ucontext_t *ContextFor(CothreadImpl *thread) {
+            return reinterpret_cast<ucontext_t *>(static_cast<UContext *>(thread)->stack.data());
+        }
 
-    /**
-     * Default stack size in bytes, if none was requested by the caller. Since this implementation
-     * may work on different width architectures, we define this as 64K worth of machine words.
-     */
-    static constexpr const size_t kDefaultStackSize{sizeof(uintptr_t) * 0x10000};
+        static void AllocMainCothread();
+        static void Prepare(UContext *thread, const Cothread::Entry &entry);
+        static void EntryStub(int id);
+        static void InvokeCothreadDidReturnHandler(Cothread *from);
 
+    public:
+        /**
+         * Requested alignment for stack allocations.
+         *
+         * 64 bytes is the most stringent alignment requirements we should probably encounter in the
+         * real world (one cache line on most systems) and alignment doesn't result in _that_ much
+         * overhead so this is fine.
+         *
+         * @remark This must be a power of 2.
+         */
+        static constexpr const size_t kStackAlignment{64};
 
-    /**
-     * Handle for the currently executing cothread in the calling physical thread. This is updated when
-     * switching cothreads, but will be `nullptr` until the first call to `SwitchTo()`.
-     */
-    static thread_local Cothread *gCurrentHandle;
+        /**
+         * Size of the stack buffer for the "fake" initial cothread, in machine words. This only needs to
+         * be large enough to fit the register stack frame. This _must_ be a power of two.
+         *
+         * It must be sufficiently large to fit an ucontext_t in it.
+         */
+        static constexpr const size_t kMainStackSize{128};
 
-    /**
-     * Pseudo-stack to use for the "main" cothread, i.e. the native kernel thread executing before
-     * a cothread is ever switched to it.
-     *
-     * This buffer receives the stack frame of the context of the thread on the first invocation to
-     * SwitchTo(). When invoking the Current() method before executing a real cothread, the
-     * returned Cothread will correspond to this buffer.
-     *
-     * It does not have to be particularly large, since the stack is actually allocated by the
-     * system already, and this "stack" only holds the register state.
-     */
-    static thread_local std::array<uintptr_t, kMainStackSize> gMainStack;
+        /**
+         * Default stack size in bytes, if none was requested by the caller. Since this implementation
+         * may work on different width architectures, we define this as 64K worth of machine words.
+         */
+        static constexpr const size_t kDefaultStackSize{sizeof(uintptr_t) * 0x10000};
 
+    private:
+        /**
+         * Pseudo-stack to use for the "main" cothread, i.e. the native kernel thread executing before
+         * a cothread is ever switched to it.
+         *
+         * This buffer receives the stack frame of the context of the thread on the first invocation to
+         * SwitchTo(). When invoking the Current() method before executing a real cothread, the
+         * returned Cothread will correspond to this buffer.
+         *
+         * It does not have to be particularly large, since the stack is actually allocated by the
+         * system already, and this "stack" only holds the register state.
+         */
+        static thread_local std::array<uintptr_t, kMainStackSize> gMainStack;
 
+        /**
+         * Since `makecontext()` is cursed and only passes parameters of `int` size of the function,
+         * this will break passing a pointer on most 64-bit platforms. Instead, we have this here
+         * map that stores an int index, which the entry wrapper pulls out and gets the context
+         * from.
+         *
+         * The value going into it is based on some counter we increment.
+         */
+        static std::unordered_map<int, std::unique_ptr<Context>> gContextInfo;
 
-    /**
-     * Since `makecontext()` is cursed and only passes parameters of `int` size of the function,
-     * this will break passing a pointer on most 64-bit platforms. Instead, we have this here map
-     * that stores an int index, which the entry wrapper pulls out and gets the context from.
-     *
-     * The value going into it is based on some counter we increment.
-     */
-    static std::unordered_map<int, std::unique_ptr<Context>> gContextInfo;
+        /**
+         * Mutex protecting access to the context map. This is taken during insertion and removal
+         * of entries in the Prepare() and entry stubs.
+         */
+        static std::mutex gContextInfoLock;
 
-    /**
-     * Mutex protecting access to the context map. This is taken during insertion and removal of
-     * entries in the Prepare() and entry stubs.
-     */
-    static std::mutex gContextInfoLock;
+        /**
+         * Value of the next integer of the context info map key.
+         */
+        static int gContextNextId;
 
-    /**
-     * Value of the next integer of the context info map key.
-     */
-    static int gContextNextId;
+    private:
+        /// When set, the stack was allocated by us and must be freed on release
+        bool ownsStack{false};
 };
 }
 

--- a/src/arch/x86/Fastcall.S
+++ b/src/arch/x86/Fastcall.S
@@ -1,12 +1,12 @@
-// Define the offsets into the `cothread_amd64::Wrapper` structure. These _MUST_ match to the actual
-// offsets of the field in the struct.
-#define COTHREAD_OFF_CONTEXT_TOP        (0x0)
+// Define the offsets into the `x86` structure. These _MUST_ match to the actual offsets of the
+// field in the struct.
+#define COTHREAD_OFF_CONTEXT_TOP        (0x10)
 
 #ifndef __cplusplus
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Define the exported symbols.
 
-.global _ZN12libcommunism8internal3x866SwitchEPNS_8CothreadES3_
+.global _ZN12libcommunism8internal3x866SwitchEPS1_S2_
 .global _ZN12libcommunism8internal3x8611JumpToEntryEv
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -21,9 +21,9 @@
 // traditionally reserved for the return value of the function, which this is a void so it may or
 // may not matter.
 //
-// void libcommunism::internal::x86::Switch(Cothread *from, Cothread *to)
+// void libcommunism::internal::x86::Switch(x86 *from, x86 *to)
 .balign 0x40
-_ZN12libcommunism8internal3x866SwitchEPNS_8CothreadES3_:
+_ZN12libcommunism8internal3x866SwitchEPS1_S2_:
     // save current state to stack and record the stack frame
     push        %ebx
     push        %esi

--- a/src/arch/x86/Fastcall.asm
+++ b/src/arch/x86/Fastcall.asm
@@ -15,7 +15,7 @@
 ;
 ; void libcommunism::internal::x86::Switch(Cothread *from, Cothread *to)
 
-?Switch@x86@internal@libcommunism@@SIXPAVCothread@3@0@Z PROC
+?Switch@x86@internal@libcommunism@@CIXPAV123@0@Z PROC
     push    EBX
     push    ESI
     push    EDI
@@ -29,7 +29,7 @@
     pop     EBX
 
     ret
-?Switch@x86@internal@libcommunism@@SIXPAVCothread@3@0@Z ENDP
+?Switch@x86@internal@libcommunism@@CIXPAV123@0@Z ENDP
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Invokes a cothread's main function.
@@ -39,10 +39,10 @@
 ;
 ; void libcommunism::internal::x86::JumpToEntry(void)
 
-?JumpToEntry@x86@internal@libcommunism@@SAXXZ PROC
+?JumpToEntry@x86@internal@libcommunism@@CAXXZ PROC
     pop     EAX
     pop     ECX
     jmp     EAX
-?JumpToEntry@x86@internal@libcommunism@@SAXXZ ENDP
+?JumpToEntry@x86@internal@libcommunism@@CAXXZ ENDP
 
 end

--- a/src/arch/x86/Fastcall.asm
+++ b/src/arch/x86/Fastcall.asm
@@ -9,7 +9,7 @@
 ; -   to (%edx): Pointer to the wrapper of the cothread we're switching to
 ;
 ; This uses the Microsoft fastcall calling convention. It's not totally clear which registers
-; need to be saved; ECX and EDX are of course used for the function arguments, and RAX is
+; need to be saved; ECX and EDX are of course used for the function arguments, and EAX is
 ; traditionally reserved for the return value of the function, which this is a void so it may or
 ; may not matter.
 ;
@@ -20,9 +20,9 @@
     push    ESI
     push    EDI
     push    EBP
-    mov     [ECX+0h], ESP
-    
-    mov     ESP, [EDX+0h]
+    mov     [ECX+10h], ESP
+
+    mov     ESP, [EDX+10h]
     pop     EBP
     pop     EDI
     pop     ESI


### PR DESCRIPTION
⚠️  **These changes break existing code because the ABI of the Cothread class changes.** ⚠️

This cleans up the way that the internals of the library are provided, with abstract implementation classes. This means we no longer need to pollute the exported `Cothread` class with members for stacks and so forth.

Additionally, the following was done:

- Fixes for compiling with Apple Clang
- Fixed linker issues on Apple platforms